### PR TITLE
Rebuild lld 14.0.6 with libxml2 2.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  dp_test: libxml2_buildout
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
- dp_test: libxml2_buildout
+  dp_test: libxml2_buildout
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+ dp_test: libxml2_buildout
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir build
 cd build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,17 +20,17 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake >=3.4.3
+    - cmake
     - m2-patch    # [win]
-    - make     # [not win]
-    - ninja    # [win]
+    - make        # [not win]
+    - ninja       # [win]
     - patch       # [not win]
   host:
-    - libcxx  # [osx]
+    - libcxx {{ version }}  # [osx]
     - libxml2 2.10
-    - llvm
-    - llvmdev =={{ version }}
-    - zlib
+    - llvm {{ version }}
+    - llvmdev {{ version }}
+    - zlib 1.2.13
   run:
     - libcxx  # [osx]
   run_constrained:
@@ -39,7 +39,7 @@ requirements:
 test:
   commands:
     - ld.lld --version  # [linux]
-    - lld-link /?  # [win]
+    - lld-link /?       # [win]
 
 about:
   home: https://lld.llvm.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [win and vc<14]
-  skip: True  # [linux and s390x]
+  skip: True  # [(win and vc<14) or (linux and s390x)]
   ignore_run_exports: # [not win]
     - libxml2         # [not win]
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,26 +11,26 @@ source:
     - patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   skip: True  # [linux and s390x]
   ignore_run_exports: # [not win]
     - libxml2         # [not win]
 requirements:
   build:
-    - cmake >=3.4.3
-    - ninja    # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make     # [not win]
-    - patch       # [not win]
+    - cmake >=3.4.3
     - m2-patch    # [win]
+    - make     # [not win]
+    - ninja    # [win]
+    - patch       # [not win]
   host:
-    - llvmdev =={{ version }}
-    - llvm
-    - libxml2
-    - zlib
     - libcxx  # [osx]
+    - libxml2 2.10
+    - llvm
+    - llvmdev =={{ version }}
+    - zlib
   run:
     - libcxx  # [osx]
   run_constrained:
@@ -47,6 +47,9 @@ about:
   license_family: Apache
   license_file: lld/LICENSE.TXT
   summary: The LLVM Linker
+  description: |
+    LLD is a linker from the LLVM project that is a drop-in replacement for system linkers and runs much faster than them. It also provides features that are useful for toolchain developers.
+    The linker supports ELF (Unix), PE/COFF (Windows), Mach-O (macOS) and WebAssembly in descending order of completeness. Internally, LLD consists of several different linkers. The ELF port is the one that will be described in this document. The PE/COFF port is complete, including Windows debug info (PDB) support. The WebAssembly port is still a work in progress
   dev_url: https://github.com/llvm/llvm-project/
   doc_url: https://github.com/llvm/llvm-project/
 


### PR DESCRIPTION
Actions:
1. Bump build number
2. Reorder dependencies
3. Add `host` pinnings
4. Add a `description`