### PR TITLE
lld v20.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,4 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-staging_channel_upload_target: llvm-20.1.8-stage2-build-0
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0
+  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,8 @@
-staging_channel_upload_target: llvm-20.1.8-stage0-build-1
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,9 @@
-staging_channel_upload_target: llvm-19.1.7-stage1-build-2
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+staging_channel_upload_target: llvm-20.1.8-stage0-build-0
 
 channels:
   - https://staging.continuum.io/prefect/llvm-19.1.7-stage1-build-2
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "19.1.7" %}
+{% set version = "20.1.8" %}
 {% set major_version = version.split(".")[0] %}
 
 package:
@@ -7,26 +7,24 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 59abea1c22e64933fad4de1671a61cdb934098793c7a31b333ff58dc41bff36c
+  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
   patches:
     - patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
 
 build:
-  number: 1
+  number: 0
   ignore_run_exports_from:
     # not actually needed on unix
     - libxml2  # [unix]
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ stdlib("c") }}
+    - {{ compiler('c') }}    
     - {{ compiler('cxx') }}
     - cmake
     - ninja
     - llvmdev =={{ version }}              # [build_platform != target_platform]
-    - patch       # [not win]
-    - m2-patch    # [win]
   host:
     - libcxx {{ cxx_compiler_version }}    # [osx]
     - llvmdev {{ version }}

--- a/recipe/patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
+++ b/recipe/patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
@@ -1,4 +1,4 @@
-From 14d6c677c1758066f1ef10635439754cc3161057 Mon Sep 17 00:00:00 2001
+From 8b71d6a493c21e14a01cc228109d73190f2bb0be Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 14 Jul 2021 21:53:53 +0200
 Subject: [PATCH] point header inclusion in lld/MachO/CMakeLists.txt to SRC_DIR
@@ -8,7 +8,7 @@ Subject: [PATCH] point header inclusion in lld/MachO/CMakeLists.txt to SRC_DIR
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/lld/MachO/CMakeLists.txt b/lld/MachO/CMakeLists.txt
-index ea26889267..3e06eb78fc 100644
+index ecf6ce609e59..a9d60edb19c4 100644
 --- a/lld/MachO/CMakeLists.txt
 +++ b/lld/MachO/CMakeLists.txt
 @@ -2,7 +2,7 @@ set(LLVM_TARGET_DEFINITIONS Options.td)
@@ -19,7 +19,4 @@ index ea26889267..3e06eb78fc 100644
 +include_directories($ENV{SRC_DIR}/libunwind/include)
  
  add_lld_library(lldMachO
-   Arch/ARM.cpp
--- 
-2.38.1.windows.1
-
+   Arch/ARM64.cpp


### PR DESCRIPTION
lld v20.1.8

## Links
- [PKG-8677](https://anaconda.atlassian.net/browse/PKG-8677)
- [Artifacts](https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0)

## Changes
- Bump version and SHA, reset build number
- Build with llvm 20
- Rebase patch

## Notes
- Linter errors appear to be false negatives.

## Related PRs
- ✅ https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/17
- ✅  https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/23
- https://github.com/AnacondaRecipes/libcxx-feedstock/pull/15
- https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/29
- https://github.com/AnacondaRecipes/clangdev-feedstock/pull/16
- https://github.com/AnacondaRecipes/compiler-rt-feedstock/pull/9
-  ✅ https://github.com/AnacondaRecipes/mlir-feedstock/pull/8
-  ✅ https://github.com/AnacondaRecipes/lld-feedstock/pull/12
- https://github.com/AnacondaRecipes/openmp-feedstock/pull/6
- https://github.com/AnacondaRecipes/clang-win-activation-feedstock/pull/6
- https://github.com/AnacondaRecipes/flang-feedstock/pull/2
- https://github.com/AnacondaRecipes/flang-activation-feedstock/pull/1

[PKG-8677]: https://anaconda.atlassian.net/browse/PKG-8677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ