### PR TITLE
Update to LLVM 21.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Build against LLVM 21 Stage 2 output (re-trigger)
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0
+
+# Build against LLVM 21 Stage 2 output
 channels:
   - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
+aggregate_check: false
+
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,11 +1,4 @@
-aggregate_check: false
-
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0
-
-# Build against LLVM 21 Stage 2 output
-channels:
-  - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0
+  - "-c https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,7 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"
+
+# Build against LLVM 21 Stage 2 output
+channels:
+  - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,7 @@ build_parameters:
 staging_channel_upload_target: llvm-21.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0
+  # Stage 2 channel has clang_bootstrap 21
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  # Stage 0 channel has supporting packages
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,6 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Build against LLVM 21 Stage 2 output
+# Build against LLVM 21 Stage 2 output (re-trigger)
 channels:
   - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,10 +2,6 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0
-
+# Note: Staging channel needed until LLVM 21 packages are promoted to pkgs/main
 channels:
-  # Stage 2 channel has clang_bootstrap 21
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-  # Stage 0 channel has supporting packages
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,8 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0"
+
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-21.1.8-stage2-build-0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,10 +3,11 @@ c_compiler:             # [osx]
 cxx_compiler:           # [osx]
   - clang_bootstrap     # [osx]
 
+# Note: Must use LLVM 20 compiler because clang_bootstrap 21 doesn't exist yet
 c_compiler_version:
-  - 21.1.8           # [osx]
+  - 20.1.8           # [osx]
 cxx_compiler_version:
-  - 21.1.8           # [osx]
+  - 20.1.8           # [osx]
 
 # Keep consistent with llvmdev and clangdev
 c_compiler:        # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,9 +4,9 @@ cxx_compiler:           # [osx]
   - clang_bootstrap     # [osx]
 
 c_compiler_version:
-  - 20.1.8           # [osx]
+  - 21.1.8           # [osx]
 cxx_compiler_version:
-  - 20.1.8           # [osx]
+  - 21.1.8           # [osx]
 
 # Keep consistent with llvmdev and clangdev
 c_compiler:        # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,11 +3,11 @@ c_compiler:             # [osx]
 cxx_compiler:           # [osx]
   - clang_bootstrap     # [osx]
 
-# Note: Must use LLVM 20 compiler because clang_bootstrap 21 doesn't exist yet
+# Stage 2: Build with clang 21 compiler
 c_compiler_version:
-  - 20.1.8           # [osx]
+  - 21.1.8           # [osx]
 cxx_compiler_version:
-  - 20.1.8           # [osx]
+  - 21.1.8           # [osx]
 
 # Keep consistent with llvmdev and clangdev
 c_compiler:        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.1.8" %}
+{% set version = "21.1.8" %}
 {% set major_version = version.split(".")[0] %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
+  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
   patches:
     - patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
 


### PR DESCRIPTION
lld 21.1.8 
  **Destination channel:** defaults

  ### Links

  - [PKG-10606](https://anaconda.atlassian.net/browse/PKG-10606)
  - [Upstream repository](https://github.com/llvm/llvm-project/tree/main/lld)
  - [Upstream changelog/diff](https://github.com/llvm/llvm-project/compare/llvmorg-20.1.8...llvmorg-21.1.8)
  -
  ### Related PRs

  - AnacondaRecipes/llvmdev-feedstock#33
  - AnacondaRecipes/clangdev-feedstock#21
  - AnacondaRecipes/libcxx-feedstock#22
  - AnacondaRecipes/cctools-and-ld64-feedstock#18
  - AnacondaRecipes/clang-compiler-activation-feedstock#24
  - AnacondaRecipes/compiler-rt-feedstock#10
  - AnacondaRecipes/mlir-feedstock#10

  ### Explanation of changes:

  - Updated version from 20.1.8 to 21.1.8
  - Updated SHA256 hash for new release tarball
  - Updated macOS compiler versions to 21.1.8
  - Fixed abs.yaml: moved channel from `-c` flag in build_parameters to `channels` section
  - Builds against `llvm-21.1.8-stage2-build-0` staging channel


[PKG-10606]: https://anaconda.atlassian.net/browse/PKG-10606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ