### PR TITLE
Update lld to LLVM 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-# Note: Staging channel needed until LLVM 21 packages are promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,11 +3,11 @@ c_compiler:             # [osx]
 cxx_compiler:           # [osx]
   - clang_bootstrap     # [osx]
 
-# Stage 2: Build with clang 21 compiler
+# Build with clang 22 compiler
 c_compiler_version:
-  - 21.1.8           # [osx]
+  - 22.1.2           # [osx]
 cxx_compiler_version:
-  - 21.1.8           # [osx]
+  - 22.1.2           # [osx]
 
 # Keep consistent with llvmdev and clangdev
 c_compiler:        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 {% set major_version = version.split(".")[0] %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+  sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
   patches:
     - patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
 


### PR DESCRIPTION
lld 22.1.2

**Destination channel:** defaults

### Links

- [PKG-13440](https://anaconda.atlassian.net/browse/PKG-13440)
- [PKG-12851](https://anaconda.atlassian.net/browse/PKG-12851) (LLVM 22 epic)
- [Upstream repository](https://github.com/llvm/llvm-project)
- [Upstream changelog](https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.2)
- Relevant dependency PRs (all released to pkgs/main):
  - libcxx 22.1.2 — AnacondaRecipes/libcxx-feedstock#25
  - llvmdev 22.1.2 — AnacondaRecipes/llvmdev-feedstock#36
  - clangdev 22.1.2 — AnacondaRecipes/clangdev-feedstock#23
  - clang-compiler-activation 22.1.2 — AnacondaRecipes/clang-compiler-activation-feedstock#28

### Explanation of changes:

- **Version bump:** 21.1.8 → 22.1.2. 

[PKG-13440]: https://anaconda.atlassian.net/browse/PKG-13440
[PKG-12851]: https://anaconda.atlassian.net/browse/PKG-12851