### PR TITLE
Rebuild against libxml2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-point-header-inclusion-in-lld-MachO-CMakeLists.txt-t.patch
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports_from:
     # not actually needed on unix
     - libxml2  # [unix]


### PR DESCRIPTION
lld 22.1.2

**Destination channel:**  defaults

### Links

- [PKG-12534](https://anaconda.atlassian.net/browse/PKG-12534) 
- [Upstream repository](https://github.com/llvm/llvm-project//tree/llvmorg-22.1.5)

### Explanation of changes:
- Rebuild against libxml2 2.14

[PKG-12534]: https://anaconda.atlassian.net/browse/PKG-12534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ